### PR TITLE
Fix comments being translated from English to English

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.google.sps</groupId>
   <artifactId>portfolio</artifactId>
-  <version>2</version>
+  <version>3</version>
   <packaging>war</packaging>
 
   <properties>
@@ -59,7 +59,7 @@
           <port>8080</port>
           -->
           <deploy.projectId>ibiyemi-step-2020</deploy.projectId>
-          <deploy.version>2</deploy.version>
+          <deploy.version>3</deploy.version>
         </configuration>
       </plugin>
     </plugins>

--- a/portfolio/src/main/java/com/google/sps/servlets/comments/CommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/comments/CommentServlet.java
@@ -169,7 +169,7 @@ public class CommentServlet extends HttpServlet {
       Translation translation = translate.translate(content, TranslateOption.targetLanguage("en"),
           TranslateOption.model("nmt"));
 
-      if (translation.getSourceLanguage() != "en") {
+      if (!translation.getSourceLanguage().equalsIgnoreCase("en")) {
         comment.setUnindexedProperty("contentTranslated",
             new Text(translation.getTranslatedText()));
         comment.setProperty("contentLang", translation.getSourceLanguage());


### PR DESCRIPTION
Comments are currently marked as translated, even if they are already in English. This PR fixes that.